### PR TITLE
mini210-qt removed unneeded files from target qt install.

### DIFF
--- a/targets/mini210-qt.conf
+++ b/targets/mini210-qt.conf
@@ -9,7 +9,6 @@ QT5CC_URL=https://github.com/ARMWorks/Qt5.6.1_armhfcc/archive/master.zip
 QT5CC_DIR=Qt5.6.1_armhfcc-master
 QT5CC_ZIP=qt5-armhfcc.zip
 
-
 read -r -d '' EXTRA_PACKAGES << EOF
 dosfstools
 kmod
@@ -66,7 +65,9 @@ EOF
         fi
 
         echo "Unpacking Qt archive."
-        run_as_user unzip -f -o ${DIBS}/$QT5CC_ZIP "$QT5CC_DIR/qt5arm/*" -d /tmp > /dev/null
+        run_as_user unzip -o ${DIBS}/$QT5CC_ZIP "$QT5CC_DIR/qt5arm/*" -d /tmp > /dev/null
+        rm -rf /tmp/$QT5CC_DIR/qt5arm/include
+        rm -rf /tmp/$QT5CC_DIR/qt5arm/doc
         run_as_user tar --transform "s#tmp/$QT5CC_DIR#usr/local#" -czf ${DIBS}/targets/mini210-qt_overlay/qt5arm.tar.gz /tmp/$QT5CC_DIR/qt5arm
     fi
 


### PR DESCRIPTION
To save space and reduce unneeded files, removed qt5arm/include and qt5arm/doc
